### PR TITLE
refine dns resolution to kube-system ns and pod kube-dns

### DIFF
--- a/11-deny-egress-traffic-from-an-application.md
+++ b/11-deny-egress-traffic-from-an-application.md
@@ -68,7 +68,7 @@ allowing it to establish connections to the `kube-dns` Pods.
 ### Allowing DNS traffic
 
 So we slightly modify the YAML file to allow all outbound traffic on DNS ports
-(`53/udp` and `53/tcp`):
+(`53/udp` and `53/tcp`), but only to pods which match the label `k8s-app: kube-dns` and are running in the kube-system namespace:
 
 ```sh
 apiVersion: networking.k8s.io/v1
@@ -87,7 +87,7 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: kube-system
-    - podSelector:
+      podSelector:
         matchLabels:
           k8s-app: kube-dns
     ports:

--- a/14-deny-external-egress-traffic.md
+++ b/14-deny-external-egress-traffic.md
@@ -31,7 +31,7 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: kube-system
-    - podSelector:
+      podSelector:
         matchLabels:
           k8s-app: kube-dns
     ports:
@@ -46,7 +46,7 @@ Few remarks about this policy:
 * This policy applies to pods with `app=foo` and in Egress (outbound) direction.
 * Similar to [DENY egress traffic from an
   application](11-deny-egress-traffic-from-an-application.md) example, this policy
-  allows all outbound traffic on ports 53/udp and 53/tcp for DNS resolution.
+  allows all outbound traffic on ports 53/udp and 53/tcp to the kube-dns pods for DNS resolution.
 * `to:` specifies a `namespaceSelector` which matches `kubernetes.io/metadata.name: kube-system` and a `podSelector` which matches `k8s-app: kube-dns`. This will select only the kube-dns pods in the kube-system namespace, so the outbound traffic to the kube-dns pods in the kube-system namespace will be allowed.
 * And since they are not listed, traffic to the IP addresses outside the cluster
   are denied.


### PR DESCRIPTION
Hey, what do you think about this change? It would be a little more strict and only allow the kube-dns pod in the kube-system  namespace.

Will the labels be stable? I think so.

